### PR TITLE
security: add explicit Content Security Policy to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,9 @@
   "name": "Podkey",
   "version": "0.0.7",
   "description": "did:nostr and Solid authentication extension - NIP-07 wallet for decentralized identity",
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
   "permissions": [
     "storage",
     "webRequest"


### PR DESCRIPTION
## Summary
- Adds an explicit `content_security_policy` field to `manifest.json` for extension pages: `script-src 'self'; object-src 'self'`
- MV3 already enforces restrictive CSP defaults, but documenting the policy explicitly prevents accidental relaxation during future development and makes the extension's trust boundary auditable at a glance
- No functional change to runtime behaviour since this matches the MV3 default

## Test plan
- [ ] Load the extension in Chrome and verify it installs without manifest errors
- [ ] Confirm the popup and options pages still load and function correctly
- [ ] Verify `chrome://extensions` shows no CSP warnings

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)