### PR TITLE
security: move private key to session-only storage (never persisted to disk)

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -219,10 +219,15 @@ async function handleExport() {
   if (!confirmed) return;
 
   try {
-    const { podkey_private_key: privateKey } = await chrome.storage.local.get(['podkey_private_key']);
+    // Private key is now stored in session storage (in-memory only).
+    // Try session storage first, fall back to local for legacy installs.
+    let { podkey_private_key: privateKey } = await chrome.storage.session.get(['podkey_private_key']);
+    if (!privateKey) {
+      ({ podkey_private_key: privateKey } = await chrome.storage.local.get(['podkey_private_key']));
+    }
 
     if (!privateKey) {
-      alert('No private key found');
+      alert('No private key found. The key may have been cleared when the browser restarted. Please re-import your key.');
       return;
     }
 
@@ -282,9 +287,9 @@ async function removeTrustedSite(origin) {
   console.log('[Podkey] Removed trusted site:', origin);
 }
 
-// Listen for storage changes
+// Listen for storage changes (local for trusted sites / pubkey, session for private key)
 chrome.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName === 'local' && currentScreen === 'main') {
+  if ((areaName === 'local' || areaName === 'session') && currentScreen === 'main') {
     loadTrustedSites();
   }
 });

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,6 +1,11 @@
 /**
  * Podkey - Secure storage for Nostr keys
- * Uses Chrome storage API with encryption
+ *
+ * Private keys are stored in chrome.storage.session (in-memory only, never
+ * persisted to disk, cleared when the service worker terminates).
+ *
+ * Public keys remain in chrome.storage.local so the popup can display the
+ * user's pubkey/DID without requiring the private key to be unlocked.
  */
 
 const STORAGE_KEYS = {
@@ -13,7 +18,9 @@ const STORAGE_KEYS = {
 };
 
 /**
- * Store private key securely
+ * Store keypair securely.
+ * Private key goes to session storage (in-memory only).
+ * Public key goes to local storage (persisted, but not secret).
  * @param {string} privateKey - 64-char hex private key
  * @param {string} publicKey - 64-char hex public key
  */
@@ -23,36 +30,46 @@ export async function storeKeypair(privateKey, publicKey) {
     throw new Error('Keys must be 64-char hex');
   }
 
+  // Private key: session storage only (in-memory, never written to disk)
+  await chrome.storage.session.set({
+    [STORAGE_KEYS.PRIVATE_KEY]: privateKey
+  });
+
+  // Public key: local storage (needs to survive service worker restarts
+  // so the popup can show the user's identity without the private key)
   await chrome.storage.local.set({
-    [STORAGE_KEYS.PRIVATE_KEY]: privateKey,
     [STORAGE_KEYS.PUBLIC_KEY]: publicKey
   });
 
-  console.log('[Podkey] Keypair stored securely');
+  // Remove any legacy private key from local storage left by older versions
+  await chrome.storage.local.remove([STORAGE_KEYS.PRIVATE_KEY]);
+
+  console.log('[Podkey] Keypair stored (private key in session storage only)');
 }
 
 /**
- * Get stored keypair
+ * Get stored keypair.
+ * Private key comes from session storage, public key from local storage.
+ * Returns null if either key is missing (e.g. service worker restarted and
+ * session storage was cleared -- user will need to re-import).
  * @returns {Promise<{privateKey: string, publicKey: string} | null>}
  */
 export async function getKeypair() {
-  const result = await chrome.storage.local.get([
-    STORAGE_KEYS.PRIVATE_KEY,
-    STORAGE_KEYS.PUBLIC_KEY
-  ]);
+  const { [STORAGE_KEYS.PRIVATE_KEY]: privateKey } =
+    await chrome.storage.session.get([STORAGE_KEYS.PRIVATE_KEY]);
 
-  if (!result[STORAGE_KEYS.PRIVATE_KEY] || !result[STORAGE_KEYS.PUBLIC_KEY]) {
+  const { [STORAGE_KEYS.PUBLIC_KEY]: publicKey } =
+    await chrome.storage.local.get([STORAGE_KEYS.PUBLIC_KEY]);
+
+  if (!privateKey || !publicKey) {
     return null;
   }
 
-  return {
-    privateKey: result[STORAGE_KEYS.PRIVATE_KEY],
-    publicKey: result[STORAGE_KEYS.PUBLIC_KEY]
-  };
+  return { privateKey, publicKey };
 }
 
 /**
- * Check if keypair exists
+ * Check if a usable keypair exists (private key in session + public key on disk).
  * @returns {Promise<boolean>}
  */
 export async function hasKeypair() {
@@ -61,16 +78,28 @@ export async function hasKeypair() {
 }
 
 /**
- * Delete stored keypair (use with caution!)
+ * Check if a public key exists on disk (may not have a private key in session).
+ * Useful for the popup to show identity even when the session has expired.
+ * @returns {Promise<string|null>} The public key hex, or null
+ */
+export async function getStoredPublicKey() {
+  const { [STORAGE_KEYS.PUBLIC_KEY]: publicKey } =
+    await chrome.storage.local.get([STORAGE_KEYS.PUBLIC_KEY]);
+  return publicKey || null;
+}
+
+/**
+ * Delete stored keypair from both session and local storage.
  * @returns {Promise<void>}
  */
 export async function deleteKeypair() {
+  await chrome.storage.session.remove([STORAGE_KEYS.PRIVATE_KEY]);
   await chrome.storage.local.remove([
-    STORAGE_KEYS.PRIVATE_KEY,
+    STORAGE_KEYS.PRIVATE_KEY, // clean up any legacy local copy
     STORAGE_KEYS.PUBLIC_KEY
   ]);
 
-  console.log('[Podkey] Keypair deleted');
+  console.log('[Podkey] Keypair deleted from all storage');
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Move private key from `chrome.storage.local` to `chrome.storage.session`** -- private key is never written to disk
- **Keep public key in `chrome.storage.local`** -- needed for popup identity display without unlocking
- **Update `popup/popup.js`** to read private key from session storage (with legacy fallback)
- **Clean up legacy copies** of private keys left in local storage by older versions

## Threat Model

`chrome.storage.local` persists data to disk as **unencrypted JSON** at a well-known, predictable path:

```
~/.config/google-chrome/Default/Local Extension Settings/<extension-id>/
```

This means:
- **Any process with filesystem read access** can extract the raw private key hex
- **Backup software** (Time Machine, rsync, cloud sync) silently copies the key to additional locations
- **Malware** targeting browser extensions can scan this directory
- **Other extensions** with `nativeMessaging` permission can read arbitrary files
- **Forensic recovery** can retrieve the key even after "deletion" (data remains on disk until overwritten)

`chrome.storage.session` (MV3 only) stores data **exclusively in memory**:
- Never serialized to disk
- Cleared when the service worker terminates (browser restart, idle timeout)
- Scoped to the extension's origin -- inaccessible to other extensions

## UX Trade-off

Users must re-import their private key after a full browser restart, since session storage is cleared when the service worker terminates. This is the same model used by hardware wallet extensions (Ledger Live) and is an acceptable trade-off for never exposing the private key on disk.

The public key remains persisted so the popup can still display the user's Nostr identity (`npub` / `did:nostr:`) without requiring re-import.

## Changes

| File | Change |
|------|--------|
| `src/storage.js` | `storeKeypair()` writes private key to `session`, public key to `local`; `getKeypair()` reads from both; `deleteKeypair()` clears both; added `getStoredPublicKey()` helper; removes legacy local copy |
| `popup/popup.js` | `handleExport()` reads from session storage first with local fallback; storage change listener handles both `local` and `session` area names |

## Test plan

- [ ] Generate a new keypair -- verify it works, popup shows identity
- [ ] Sign an event -- verify signing still works (private key loaded from session)
- [ ] Export private key from popup -- verify it reads from session storage
- [ ] Restart browser -- verify private key is gone (user must re-import), but public key / DID still displays
- [ ] Inspect `Local Extension Settings/<id>/` on disk -- verify no private key present
- [ ] Legacy upgrade: install old version, generate key, upgrade to this version -- verify storeKeypair removes local copy