### PR TITLE
fix: remove unused webRequest permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,7 @@
   "version": "0.0.7",
   "description": "did:nostr and Solid authentication extension - NIP-07 wallet for decentralized identity",
   "permissions": [
-    "storage",
-    "webRequest"
+    "storage"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
## Summary
- Removes the `webRequest` permission from `manifest.json` — it is declared but never used anywhere in the codebase
- The background script explicitly comments that `webRequestBlocking` is deprecated in MV3 and the extension uses JavaScript-level fetch/XHR interception instead
- Grep across all `.js` files confirms zero `chrome.webRequest` API calls
- Reduces the extension's privilege surface and avoids unnecessary Chrome Web Store review flags

## Test plan
- [ ] Load the extension and verify it installs without errors
- [ ] Confirm NIP-98 auth header injection still works (fetch interception is JS-level, not webRequest-based)
- [ ] Verify NIP-07 signing still works on a Nostr client page

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)