### PR TITLE
security: sanitize HTML in popup trusted-origins list (XSS fix)

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -247,23 +247,28 @@ async function loadTrustedSites() {
     return;
   }
 
-  listEl.innerHTML = origins
-    .sort()
-    .map(origin => `
-      <div class="trusted-item">
-        <span class="trusted-origin">${origin}</span>
-        <button class="btn-remove" data-origin="${origin}">Remove</button>
-      </div>
-    `)
-    .join('');
+  listEl.innerHTML = '';
+  origins.sort().forEach(origin => {
+    const div = document.createElement('div');
+    div.className = 'trusted-item';
 
-  // Add remove button handlers
-  listEl.querySelectorAll('.btn-remove').forEach(btn => {
+    const span = document.createElement('span');
+    span.className = 'trusted-origin';
+    span.textContent = origin;
+
+    const btn = document.createElement('button');
+    btn.className = 'btn-remove';
+    btn.dataset.origin = origin;
+    btn.textContent = 'Remove';
+
     btn.addEventListener('click', async () => {
-      const origin = btn.dataset.origin;
       await removeTrustedSite(origin);
       await loadTrustedSites(); // Reload
     });
+
+    div.appendChild(span);
+    div.appendChild(btn);
+    listEl.appendChild(div);
   });
 }
 


### PR DESCRIPTION
## Summary
- **Severity**: HIGH-02 (XSS in privileged popup context)
- Replace `innerHTML` template literal interpolation with DOM API methods (`createElement`, `textContent`, `appendChild`) when rendering the trusted origins list in `popup/popup.js`
- The previous code interpolated the `origin` string directly into HTML via template literals, allowing an attacker who gets a malicious string into the trusted origins list (e.g. `<img src=x onerror="...">`) to execute arbitrary JavaScript in the popup's privileged extension context, potentially exfiltrating the user's private key
- Verified no other `innerHTML` usage in `popup.js` involves user-controlled data

## Test plan
- [ ] Load extension and navigate to a site, approve trust prompt
- [ ] Verify trusted origins list renders correctly in popup
- [ ] Verify "Remove" buttons still work for each trusted origin
- [ ] Manually add a malicious-looking origin string to storage (e.g. `<img src=x onerror="alert(1)">`) and verify it renders as escaped text, not executed HTML

Co-Authored-By: claude-flow <ruv@ruv.net>