### PR TITLE
fix: remove broken bech32 nsec/npub stub functions

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -161,35 +161,3 @@ export function isValidPublicKey (publicKey) {
   if (publicKey.length !== 64) return false;
   return /^[0-9a-fA-F]{64}$/.test(publicKey);
 }
-
-/**
- * Convert private key to nsec format (Bech32)
- * @param {string} privateKeyHex - 64-char hex private key
- * @returns {string} nsec1... format
- */
-export function privateKeyToNsec (privateKeyHex) {
-  // TODO: Implement bech32 encoding
-  // For now, return hex with nsec prefix as placeholder
-  return `nsec_${privateKeyHex}`;
-}
-
-/**
- * Convert nsec to private key hex
- * @param {string} nsec - nsec1... format
- * @returns {string} 64-char hex private key
- */
-export function nsecToPrivateKey (nsec) {
-  // TODO: Implement bech32 decoding
-  // For now, strip nsec_ prefix as placeholder
-  return nsec.replace(/^nsec_/, '');
-}
-
-/**
- * Convert public key to npub format (Bech32)
- * @param {string} publicKeyHex - 64-char hex public key
- * @returns {string} npub1... format
- */
-export function publicKeyToNpub (publicKeyHex) {
-  // TODO: Implement bech32 encoding
-  return `npub_${publicKeyHex}`;
-}


### PR DESCRIPTION
## Summary
- Removes three broken NIP-19 stub functions from `src/crypto.js`: `privateKeyToNsec`, `nsecToPrivateKey`, and `publicKeyToNpub`
- These functions emitted fake `nsec_<hex>` / `npub_<hex>` strings that are NOT valid NIP-19 bech32 encoding, which could confuse users into thinking they have a valid key backup
- Grep confirms none of these functions are imported or called anywhere in the codebase — they are dead code
- Proper NIP-19 bech32 support can be added when needed via a bech32 library (e.g. `@scure/base`)

## Test plan
- [ ] Verify the extension builds without import errors (functions are unused)
- [ ] Confirm key generation and signing still work (unrelated code paths)
- [ ] Run existing tests to verify no regressions

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)