### PR TITLE
security: fix Solid server auto-trust hostname matching

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -330,16 +330,23 @@ function encodeNip98Header (signedEvent) {
  * @returns {boolean}
  */
 function isLikelySolidServer (origin) {
-  // Common Solid server indicators
-  const solidIndicators = [
+  let hostname;
+  try {
+    hostname = new URL(origin).hostname;
+  } catch {
+    return false;
+  }
+
+  const trustedHosts = [
     'solid.social',
     'solidcommunity.net',
     'inrupt.net',
-    'solidweb.org',
-    '/.well-known/solid'
+    'solidweb.org'
   ];
 
-  return solidIndicators.some(indicator => origin.includes(indicator));
+  return trustedHosts.some(trusted =>
+    hostname === trusted || hostname.endsWith('.' + trusted)
+  );
 }
 
 async function createNip98AuthHeader (url, method, body = null) {


### PR DESCRIPTION
## Summary
- **Severity**: HIGH-03 (auto-trust bypass via substring matching)
- Replace `String.includes()` substring matching in `isLikelySolidServer()` with exact hostname matching via `new URL().hostname`
- The previous code allowed any domain containing a trusted substring to be auto-trusted (e.g. `evil-solid.social.attacker.com` matched `solid.social`, `not-solidcommunity.net.evil.com` matched `solidcommunity.net`)
- Now performs exact hostname match or legitimate subdomain match (`hostname === trusted || hostname.endsWith('.' + trusted)`)
- Removes the `'/.well-known/solid'` indicator which never matched since origins don't contain paths
- Invalid origins that fail URL parsing return `false` instead of potentially throwing

## Test plan
- [ ] Verify `https://solid.social` still matches as a Solid server
- [ ] Verify `https://pod.solid.social` still matches (subdomain)
- [ ] Verify `https://evil-solid.social.attacker.com` does NOT match
- [ ] Verify `https://not-solidcommunity.net.evil.com` does NOT match
- [ ] Verify malformed origins (non-URL strings) return false without throwing

Co-Authored-By: claude-flow <ruv@ruv.net>