### PR TITLE
security: whitelist message types in content script relay

### DIFF
--- a/src/injected.js
+++ b/src/injected.js
@@ -314,17 +314,47 @@ script.onload = function () {
 };
 (document.head || document.documentElement).appendChild(script);
 
+// Allowed message types that can be forwarded to the background script
+const ALLOWED_TYPES = new Set([
+  'GET_PUBLIC_KEY',
+  'SIGN_EVENT',
+  'GET_RELAYS',
+  'NIP04_ENCRYPT',
+  'NIP04_DECRYPT',
+  'NIP44_ENCRYPT',
+  'NIP44_DECRYPT'
+]);
+
 // Listen for requests from the injected script
 window.addEventListener('podkey-request', async (event) => {
   const { id, type, ...data } = event.detail;
 
   console.log('[Podkey] Received request:', type, 'from page');
 
+  if (!ALLOWED_TYPES.has(type)) {
+    console.warn('[Podkey] Rejected unknown request type:', type);
+    window.dispatchEvent(new CustomEvent('podkey-response', {
+      detail: { id, error: 'Unknown request type' }
+    }));
+    return;
+  }
+
+  // Only forward known safe fields per message type
+  const safeData = {};
+  if (type === 'SIGN_EVENT' && data.event) {
+    safeData.event = data.event;
+  } else if ((type === 'NIP04_ENCRYPT' || type === 'NIP04_DECRYPT' ||
+              type === 'NIP44_ENCRYPT' || type === 'NIP44_DECRYPT')) {
+    if (data.peer) safeData.peer = String(data.peer);
+    if (data.plaintext !== undefined) safeData.plaintext = String(data.plaintext || '');
+    if (data.ciphertext !== undefined) safeData.ciphertext = String(data.ciphertext);
+  }
+
   try {
-    // Forward to background script
+    // Forward to background script with only validated fields
     const response = await chrome.runtime.sendMessage({
       type,
-      ...data,
+      ...safeData,
       origin: window.location.origin
     });
 


### PR DESCRIPTION
## Summary
- **Severity**: HIGH-01 partial (arbitrary message type injection)
- Add an `ALLOWED_TYPES` whitelist (`Set`) to validate the `type` field from page events before forwarding to the background script in `src/injected.js`
- The previous code forwarded the `type` field directly from page events with no validation, and the spread operator (`...data`) forwarded arbitrary fields, allowing a malicious page to invoke internal extension message handlers (e.g. `GENERATE_KEYPAIR`, `IMPORT_KEYPAIR`) or inject unexpected data fields
- Now only known NIP message types are forwarded: `GET_PUBLIC_KEY`, `SIGN_EVENT`, `GET_RELAYS`, `NIP04_ENCRYPT`, `NIP04_DECRYPT`, `NIP44_ENCRYPT`, `NIP44_DECRYPT`
- Per-type field sanitization ensures only expected fields are included in forwarded messages
- Unknown types receive an immediate error response without reaching the background script

## Test plan
- [ ] Verify `window.nostr.getPublicKey()` still works from a trusted page
- [ ] Verify `window.nostr.signEvent()` still works with valid event data
- [ ] Verify a page sending `type: 'GENERATE_KEYPAIR'` via podkey-request is rejected
- [ ] Verify a page sending `type: 'IMPORT_KEYPAIR'` via podkey-request is rejected
- [ ] Verify unknown type values receive an error response
- [ ] Verify extra fields in the event detail are not forwarded to the background script

Co-Authored-By: claude-flow <ruv@ruv.net>