### PR TITLE
security: implement signing approval popup (replace silent auto-approve)

### DIFF
--- a/popup/approve.html
+++ b/popup/approve.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PodKey - Signing Request</title>
+  <link rel="stylesheet" href="popup.css">
+  <style>
+    body { width: 380px; min-height: 200px; }
+    .approve-container { padding: 16px; }
+    .approve-header {
+      margin: 0 0 12px;
+      font-size: 18px;
+      font-weight: 700;
+      background: linear-gradient(135deg, #ef4444 0%, #f97316 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .origin-badge {
+      background: #1a1a2e;
+      color: #e94560;
+      padding: 6px 10px;
+      border-radius: 6px;
+      font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+      font-size: 13px;
+      word-break: break-all;
+    }
+    .action-text {
+      margin: 12px 0;
+      color: #475569;
+      font-size: 14px;
+      font-weight: 500;
+    }
+    .event-preview {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      padding: 10px;
+      border-radius: 6px;
+      font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+      font-size: 11px;
+      max-height: 120px;
+      overflow-y: auto;
+      color: #64748b;
+      margin: 8px 0;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+    .btn-row {
+      display: flex;
+      gap: 10px;
+      margin-top: 16px;
+    }
+    .btn-row button {
+      flex: 1;
+      padding: 12px;
+      border: none;
+      border-radius: 10px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+    .btn-approve {
+      background: linear-gradient(135deg, #4ade80 0%, #22c55e 100%);
+      color: #052e16;
+      box-shadow: 0 4px 12px rgba(34, 197, 94, 0.25);
+    }
+    .btn-deny {
+      background: linear-gradient(135deg, #fca5a5 0%, #ef4444 100%);
+      color: #450a0a;
+      box-shadow: 0 4px 12px rgba(239, 68, 68, 0.25);
+    }
+    .btn-approve:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 16px rgba(34, 197, 94, 0.35);
+    }
+    .btn-deny:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 16px rgba(239, 68, 68, 0.35);
+    }
+    .timeout-bar {
+      margin-top: 12px;
+      height: 3px;
+      background: #e2e8f0;
+      border-radius: 2px;
+      overflow: hidden;
+    }
+    .timeout-bar-inner {
+      height: 100%;
+      background: linear-gradient(90deg, #ef4444 0%, #f97316 100%);
+      width: 100%;
+      animation: shrink 60s linear forwards;
+    }
+    @keyframes shrink {
+      from { width: 100%; }
+      to { width: 0%; }
+    }
+  </style>
+</head>
+<body>
+  <div class="approve-container">
+    <h3 class="approve-header">Signing Request</h3>
+    <div class="origin-badge" id="origin"></div>
+    <div class="action-text" id="action"></div>
+    <div class="event-preview" id="preview"></div>
+    <div class="btn-row">
+      <button class="btn-deny" id="deny">Deny</button>
+      <button class="btn-approve" id="approve">Approve</button>
+    </div>
+    <div class="timeout-bar"><div class="timeout-bar-inner"></div></div>
+  </div>
+  <script src="approve.js"></script>
+</body>
+</html>

--- a/popup/approve.js
+++ b/popup/approve.js
@@ -1,0 +1,55 @@
+/**
+ * Podkey - Signing Approval Popup
+ * Presents signing requests to the user for explicit approval/denial.
+ */
+
+const params = new URLSearchParams(window.location.search);
+const requestId = params.get('id');
+const origin = params.get('origin') || 'Unknown';
+const action = params.get('action') || 'sign';
+const preview = params.get('preview') || '';
+
+// Populate UI
+document.getElementById('origin').textContent = origin;
+document.getElementById('action').textContent = `wants to: ${action}`;
+
+if (preview) {
+  try {
+    // Try to pretty-print JSON previews
+    const parsed = JSON.parse(preview);
+    document.getElementById('preview').textContent = JSON.stringify(parsed, null, 2);
+  } catch {
+    document.getElementById('preview').textContent = preview;
+  }
+} else {
+  document.getElementById('preview').style.display = 'none';
+}
+
+// Approve button
+document.getElementById('approve').addEventListener('click', () => {
+  chrome.runtime.sendMessage({
+    type: 'APPROVE_SIGNING',
+    requestId,
+    approved: true
+  });
+  window.close();
+});
+
+// Deny button
+document.getElementById('deny').addEventListener('click', () => {
+  chrome.runtime.sendMessage({
+    type: 'APPROVE_SIGNING',
+    requestId,
+    approved: false
+  });
+  window.close();
+});
+
+// Also deny on window close (user closes the popup without clicking)
+window.addEventListener('beforeunload', () => {
+  chrome.runtime.sendMessage({
+    type: 'APPROVE_SIGNING',
+    requestId,
+    approved: false
+  });
+});

--- a/src/background.js
+++ b/src/background.js
@@ -36,8 +36,21 @@ chrome.runtime.onInstalled.addListener(async () => {
   }
 });
 
+// Pending signing approval promises: requestId -> resolve function
+const pendingApprovals = new Map();
+
 // Handle messages from content scripts and popup
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  // Handle signing approval responses from the approve popup
+  if (message.type === 'APPROVE_SIGNING') {
+    const resolve = pendingApprovals.get(message.requestId);
+    if (resolve) {
+      pendingApprovals.delete(message.requestId);
+      resolve(message.approved === true);
+    }
+    return; // synchronous, no sendResponse needed
+  }
+
   handleMessage(message, sender)
     .then(result => {
       console.log('[Podkey] Message handled successfully:', message.type, result);
@@ -110,7 +123,7 @@ async function handleGetPublicKey (origin, sender) {
 
   if (!trusted) {
     // Show permission prompt
-    const allowed = await showPermissionPrompt(origin, 'share your public key');
+    const allowed = await showPermissionPrompt(origin, 'read your public key');
 
     if (!allowed) {
       throw new Error('User denied permission');
@@ -148,12 +161,14 @@ async function handleSignEvent (event, origin, sender) {
   let shouldSign = trusted && autoSign && isSolidAuth;
 
   if (!shouldSign) {
-    // Show signing prompt
-    const eventPreview = formatEventForPrompt(event);
-    const allowed = await showPermissionPrompt(
-      origin,
-      `sign this ${isSolidAuth ? 'Solid authentication' : 'event'}:\n\n${eventPreview}`
-    );
+    // Show signing prompt with event preview
+    const actionLabel = isSolidAuth ? 'sign a Solid authentication event' : `sign an event (kind ${event.kind})`;
+    const previewData = JSON.stringify({
+      kind: event.kind,
+      content: (event.content || '').substring(0, 200),
+      tags: (event.tags || []).length
+    });
+    const allowed = await showPermissionPrompt(origin, actionLabel, previewData);
 
     if (!allowed) {
       throw new Error('User denied signing');
@@ -256,30 +271,51 @@ async function handleGetKeypairStatus () {
 }
 
 /**
- * Show permission prompt to user
- * Note: Service workers can't use confirm(), so we auto-approve for now
- * TODO: Implement proper UI using chrome.notifications or action badge
+ * Show permission prompt to user via a popup window.
+ * Opens popup/approve.html and waits for the user to approve or deny.
+ * Auto-denies after 60 seconds if no response.
+ * @param {string} origin - The requesting origin
+ * @param {string} action - Human-readable description of the action
+ * @param {string} [eventPreview] - Optional preview of the event data
+ * @returns {Promise<boolean>} True if user approved
  */
-async function showPermissionPrompt (origin, action) {
-  // For now, auto-approve requests (service workers can't use confirm())
-  // In production, this should show a notification or update the badge
-  console.log(`[Podkey] Auto-approving: ${origin} wants to ${action}`);
+async function showPermissionPrompt (origin, action, eventPreview) {
+  const requestId = crypto.randomUUID();
 
-  // TODO: Show notification using chrome.notifications API
-  // For now, return true to auto-approve
-  return true;
+  return new Promise((resolve) => {
+    pendingApprovals.set(requestId, resolve);
 
-  // Future implementation:
-  // return new Promise((resolve) => {
-  //   chrome.notifications.create({
-  //     type: 'basic',
-  //     iconUrl: 'icons/128x128.png',
-  //     title: 'Podkey Permission Request',
-  //     message: `${origin} wants to ${action}`
-  //   }, (notificationId) => {
-  //     // Handle user response via notification buttons
-  //   });
-  // });
+    // Auto-deny after 60 seconds if no response
+    const timeout = setTimeout(() => {
+      if (pendingApprovals.has(requestId)) {
+        pendingApprovals.delete(requestId);
+        console.log(`[Podkey] Signing request ${requestId} timed out, auto-denying`);
+        resolve(false);
+      }
+    }, 60000);
+
+    // Clean up timeout when resolved normally
+    const originalResolve = resolve;
+    pendingApprovals.set(requestId, (approved) => {
+      clearTimeout(timeout);
+      originalResolve(approved);
+    });
+
+    const params = new URLSearchParams({
+      id: requestId,
+      origin: origin || 'Unknown',
+      action: action || 'sign',
+      preview: eventPreview || ''
+    });
+
+    chrome.windows.create({
+      url: `popup/approve.html?${params.toString()}`,
+      type: 'popup',
+      width: 420,
+      height: 380,
+      focused: true
+    });
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Replace `showPermissionPrompt()` auto-approve stub** with a real popup-based approval flow
- **New `popup/approve.html` + `popup/approve.js`**: Approval dialog showing origin, action, and event preview
- **60-second auto-deny timeout** prevents abandoned prompts from blocking indefinitely

## Security Impact (CRITICAL)

This is the most critical security fix. The current `showPermissionPrompt()` implementation:

```javascript
async function showPermissionPrompt(origin, action) {
  console.log(`[Podkey] Auto-approving: ${origin} wants to ${action}`);
  return true; // <-- EVERY request is silently approved
}
```

**Every website can silently sign Nostr events as the user.** A malicious page can:
1. Call `window.nostr.signEvent()` to sign arbitrary events (posts, DMs, delegation tokens)
2. Call `window.nostr.getPublicKey()` to identify the user
3. The user sees no prompt, no notification, nothing

This completely defeats the purpose of a signing extension. The user's identity is effectively compromised the moment they visit any page with JavaScript.

## How the Fix Works

The new flow follows the established pattern used by **nos2x**, **Alby**, and other NIP-07 extensions:

1. Website calls `window.nostr.signEvent(event)`
2. Content script forwards to background service worker
3. `showPermissionPrompt()` generates a unique `requestId` and opens `popup/approve.html` via `chrome.windows.create()`
4. The popup displays:
   - The requesting **origin** (e.g., `https://evil-site.com`)
   - The **action** being requested (e.g., "sign an event (kind 1)")
   - A **preview** of the event data (kind, truncated content, tag count)
   - A **countdown bar** showing the 60-second timeout
5. User clicks **Approve** or **Deny**
6. `approve.js` sends `APPROVE_SIGNING` message back to background
7. Background resolves the pending Promise and proceeds accordingly

If the user closes the popup without clicking, the `beforeunload` handler sends a deny. If 60 seconds pass with no response, the request is auto-denied.

## Files Changed

| File | Change |
|------|--------|
| `src/background.js` | Replace auto-approve with popup-based `showPermissionPrompt()`; add `pendingApprovals` Map; handle `APPROVE_SIGNING` messages; pass event preview data to prompts |
| `popup/approve.html` | New approval dialog with origin badge, action text, event preview, approve/deny buttons, timeout countdown bar |
| `popup/approve.js` | Handle URL params, wire up approve/deny buttons, send `APPROVE_SIGNING` messages, deny on window close |

## Test plan

- [ ] Load extension, visit a test page that calls `window.nostr.getPublicKey()` -- verify approval popup appears
- [ ] Click **Deny** -- verify the calling page receives an error
- [ ] Click **Approve** -- verify the calling page receives the public key
- [ ] Test `window.nostr.signEvent()` -- verify popup shows event kind and content preview
- [ ] Close the popup window without clicking a button -- verify request is denied
- [ ] Wait 60 seconds without interacting -- verify request is auto-denied
- [ ] Verify trusted origins still auto-approve for Solid auth events (kind 27235) with auto-sign enabled
- [ ] Verify the popup opens focused and in front of the browser window